### PR TITLE
suppress warning on Rails 3.2.0

### DIFF
--- a/lib/active_groonga/base.rb
+++ b/lib/active_groonga/base.rb
@@ -22,7 +22,6 @@ module ActiveGroonga
     extend ActiveModel::Naming
     include ActiveModel::Conversion
     include ActiveModel::AttributeMethods
-    attribute_method_suffix ""
     attribute_method_suffix "="
 
     cattr_accessor :logger, :instance_writer => false


### PR DESCRIPTION
以下の警告がでていたので、内容に従って空で定義されていた attribute_method_suffix を削除しました。

DEPRECATION WARNING: Specifying an empty prefix/suffix for an attribute method is no longer necessary. If the un-prefixed/suffixed version of the method has not been defined when `define_attribute_methods` is called, it will be defined automatically.
