### PR TITLE
fix path for test scripts

### DIFF
--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -55,7 +55,7 @@ $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.unshift(test_dir)
 require 'active-groonga-test-utils'
 
-Dir.glob("test/**/test{_,-}*.rb") do |file|
+Dir.glob(test_dir + "**/test{_,-}*.rb") do |file|
   require file.sub(/\.rb$/, '')
 end
 


### PR DESCRIPTION
テスト用のファイルを読み込むパスを $LOAD_PATH にプロジェクトルートが含まれているかどうかに依存しないように修正してみました。

背景:

RubyGems Environment:
- RUBYGEMS VERSION: 1.8.10
- RUBY VERSION: 1.9.3 (2011-10-30 patchlevel 0) [x86_64-darwin10.8.0]

な環境にclone してきて

> bundle install
> bundle exec ruby test-run_test.rb

とやると以下のエラーがでてしまっていました。

test/run-test.rb:60:in `require': cannot load such file -- test/test-associations (LoadError)
    from test/run-test.rb:60:in`block in <main>'
    from test/run-test.rb:59:in `glob'
    from test/run-test.rb:59:in`<main>'

これは、修正した箇所がプロジェクトルートが $LOAD_PATH に含まれていることを前提としているけれど、実行環境(Ruby1.9系)だと明示的に指定しないと含まれなくなったことによることが原因だと思ったので、それに影響されないよう test_dir から辿るように修正してみました。どうですかねぃ。
