### PR TITLE
invariably close database when run test case

### DIFF
--- a/test/active-groonga-test-utils.rb
+++ b/test/active-groonga-test-utils.rb
@@ -236,6 +236,7 @@ module ActiveGroongaTestUtils
   end
 
   def teardown_sand_box
+    @database.close
     teardown_tmp_directory
   end
 


### PR DESCRIPTION
テストケースを実行後に Groonga::Database を必ず close するようにしました。

背景:

テストを実行した際に以下のエラーがでるようになっていました。

Groonga::TooManyOpenFiles: too many open files: syscall error '/.../activegroonga/test/tmp/groonga/database.tables/bookmarks.columns/comment' (Too many open f: [#<Groonga::Array id: <258>, name: <bookmarks>, path: </.../activegroonga/test/tmp/groonga/database.tables/bookmarks>, domain: (nil), range: (nil), flags: <WITH_SUBREC>, size: <0>>, ["comment", "Text", {:path=>"/.../activegroonga/test/tmp/groonga/database.tables/bookmarks.columns/comment"}]]
io.c:1803: grn_open()

これは #setup_database で create している Groonga::Database を close していないことによるものと考えます。teardown の中で明示的に close を書くようにして現象が再現しないことを確認したので、パッチを送らせていただきます。
