### PR TITLE
Add activerecord.gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /Gemfile.lock
 /.yardoc/
 /doc/po/*.pot
-/*.gemspec

--- a/activerecord.gemspec
+++ b/activerecord.gemspec
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/active_groonga/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Kouhei Sutou"]
+  gem.email         = ["kou@clear-code.com"]
+  gem.description   = %q{A library to use groonga with ActiveRecord like API.}
+  gem.summary       = %q{groonga with ActiveRecord like API}
+  gem.homepage      = "http://ranguba.org/"
+
+  gem.files         = `git ls-files`.split($\)
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name          = "activegroonga"
+  gem.require_paths = ["lib"]
+  gem.version       = ActiveGroonga::VERSION::STRING
+end

--- a/test/test-version.rb
+++ b/test/test-version.rb
@@ -1,0 +1,23 @@
+# Copyright (C) 2009-2010  Kouhei Sutou <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+class TestVersion < Test::Unit::TestCase
+  include ActiveGroongaTestUtils
+
+  def test_version
+    assert_equal(ActiveGroonga::VERSION::STRING, '1.0.8')
+  end
+end


### PR DESCRIPTION
Gemfileでsourceを https://rubygems.org にしているとバージョン1.0.7しかインストールできず、エッジを試したい時にGemfileで次のように指定できるようにしたほうが選択肢が広がってよいのではないかと思いますが、いかがでしょうか？

``` ruby
gem 'activegroonga', :git => 'https://github.com/ranguba/activegroonga.git'
```
