### PR TITLE
Fix "Don't know how to build task 'rails_env'" when running rake tasks

### DIFF
--- a/lib/active_groonga/railties/groonga.rake
+++ b/lib/active_groonga/railties/groonga.rake
@@ -16,7 +16,10 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 namespace :groonga do
-  task :load_config => :rails_env do
+  task :load_config do
+    if Rake::Task.task_defined?("rails_env")
+      Rake::Task["rails_env"].invoke
+    end
     require "active_groonga"
     configurations = Rails.application.config.groonga_configurations
     ActiveGroonga::Base.configurations = configurations


### PR DESCRIPTION
With Rails 4, running rake tasks such as "groonga:setup" is failing. This is because 'rails_env' task has been removed in Rails 4 (rails/rails@9abf589051006b62a2c7f8cf614eff629a083fd5).

This PR would fix the failure by first checking if "rails_env" task exists and then invoking the task in "groonga:load_config".
