### PR TITLE
Remove unnecessary require in ActiveGroonga::Database

### DIFF
--- a/lib/active_groonga/database.rb
+++ b/lib/active_groonga/database.rb
@@ -13,8 +13,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-require 'fileutils'
-
 module ActiveGroonga
   class Database
     def initialize(path)


### PR DESCRIPTION
I think that this should be removed. All tests are passed even after removing it.
