### PR TITLE
Yield block on ActiveGroonga::Base.new

### DIFF
--- a/lib/active_groonga/base.rb
+++ b/lib/active_groonga/base.rb
@@ -95,8 +95,7 @@ module ActiveGroonga
             create(nested_attributes, &block)
           end
         else
-          object = new(attributes)
-          yield(object) if block_given?
+          object = new(attributes, &block)
           object.save
           object
         end
@@ -272,6 +271,7 @@ module ActiveGroonga
         reload_attributes
         self.attributes = (record_or_attributes || {})
       end
+      yield self if block_given?
     end
 
     def have_column?(name)

--- a/test/test-base.rb
+++ b/test/test-base.rb
@@ -47,6 +47,16 @@ class TestBase < Test::Unit::TestCase
     assert_equal("send mails", send_mail.name)
   end
 
+  def test_create_with_block
+    yahoo_japan = Site.new do |s|
+      s.key = 'http://www.yahoo.co.jp/'
+      s.title = 'Yahoo! Japan'
+      s.score = 5
+    end
+    assert_not_nil(yahoo_japan.key)
+    assert_true(yahoo_japan.save)
+  end
+
   def test_update
     groonga_id = @bookmark_records[:groonga].id
     groonga = Bookmark.find(groonga_id)


### PR DESCRIPTION
It would be nice if `ActiveGroonga::Base.new` yields block. I think that block emphasizes what attributes are initialized when calling `.new`.

You could use `#tap` method instead. Since `ActiveRecord::Base.new` yields block, `ActiveGroonga::Base.new` should yield block as well.
