### PR TITLE
Use environment variable to decide which rroonga to use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,8 @@
 source "https://rubygems.org"
 
 gemspec
+
+if ENV["USE_RROONGA_GITHUB_REPO"]
+  puts ENV["USE_RRONGA_GITHUB_REPO"]
+  gem 'rroonga', github: ENV["USE_RROONGA_GITHUB_REPO"]
+end

--- a/activegroonga.gemspec
+++ b/activegroonga.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("test-unit")
   spec.add_development_dependency("test-unit-notify")
   spec.add_development_dependency("rake")
-  spec.add_development_dependency("bundler")
+  spec.add_development_dependency("bundler", ">= 1.3.0")
   spec.add_development_dependency("packnga", ">= 0.9.7")
   spec.add_development_dependency("RedCloth")
 end

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -27,24 +27,8 @@ require "test/unit/notify"
 
 base_dir = Pathname(__FILE__).dirname.parent.expand_path
 
-rroonga_dir = base_dir.parent + "rroonga"
 lib_dir = base_dir + "lib"
 test_dir = base_dir + "test"
-
-if rroonga_dir.exist?
-  make = nil
-  if system("which gmake > /dev/null")
-    make = "gmake"
-  elsif system("which make > /dev/null")
-    make = "make"
-  end
-  if make
-    escaped_rroonga_dir = Shellwords.escape(rroonga_dir.to_s)
-    system("cd #{escaped_rroonga_dir} && #{make} > /dev/null") or exit(false)
-  end
-  $LOAD_PATH.unshift(rroonga_dir + "ext" + "groonga")
-  $LOAD_PATH.unshift(rroonga_dir + "lib")
-end
 
 ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] = "10000"
 


### PR DESCRIPTION
With this PR, when testing activegroonga, one can fetch and build rroonga from GitHub repo. With [local git repo](http://bundler.io/v1.3/git.html#local) feature of Bundler, she/he can choose local git repository.

I was surprised when activegroonga's test suddenly start failing with error ("make: **\* No targets specified and no makefile found."). After looking at `test/run-test.rb`, I realized that the script tried to execute `make` to build rroonga from local repository which I recently cloned.

I thought that builing gem and resolving load path are not test's job. They should be handled with Bundler/RubyGem and by developer. So, I propose this PR. 
