### PR TITLE
Execute make to build rroonga only when Makefile exists

### DIFF
--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -31,7 +31,9 @@ rroonga_dir = base_dir.parent + "rroonga"
 lib_dir = base_dir + "lib"
 test_dir = base_dir + "test"
 
-if rroonga_dir.exist?
+makefile = rroonga_dir.join("Makefile")
+
+if rroonga_dir.exist? && makefile.exist?
   make = nil
   if system("which gmake > /dev/null")
     make = "gmake"


### PR DESCRIPTION
This PR is similar to #12, but it adds one more check if rroonga's Makefile exists before running tests.
