### PR TITLE
Fix Groonga::NoSuchColumn error when interating ResultSet

### DIFF
--- a/lib/active_groonga/result_set.rb
+++ b/lib/active_groonga/result_set.rb
@@ -181,7 +181,7 @@ module ActiveGroonga
         resolved_record = resolved_record.key
       end
       instance = @klass.instantiate(resolved_record)
-      instance.score = record.score
+      instance.score = record.score if record.support_score?
       instance
     end
 

--- a/test/test-result-set.rb
+++ b/test/test-result-set.rb
@@ -141,6 +141,16 @@ class TestResultSet < Test::Unit::TestCase
     end
   end
 
+  class TestEach < self
+    def test_records_of_hash_without_score
+      groonga = Site.create(:key => "http://groonga.org/",
+                            :title => "groonga")
+      Page.create(:key => "http://groonga.org/doc/",
+                  :site => groonga)
+      assert_nothing_raised { Page.select.each { |r| r } }
+    end
+  end
+
   class TestEmpty < self
     def test_have_records
       all_bookmarks = Bookmark.all


### PR DESCRIPTION
This PR fixes `Groonga::NoSuchColumn: no such column: <"_score">` error that is raised when iterating ResultSet that is created with ActiveGroonga::Base#select of Groonga::Hash table.

The following script raises Groonga::NoSuchColumn error.

``` ruby
require 'active_groonga'

db_path = '/tmp/db.groonga'
begin
  Groonga::Database.new(db_path)
rescue Groonga::NoSuchFileOrDirectory
  Groonga::Database.create(path: db_path)
end

Groonga::Schema.remove_table('sites') if Groonga['sites']
Groonga::Schema.create_table('sites', type: :hash) do |table|
  table.text('title')
end

class Site < ActiveGroonga::Base
  table_name('sites')
end

[
  ['http://www.yahoo.com', 'Yahoo!'],
  ['http://www.google.com', 'Google']
].each do |uri, title|
  Site.new(key: uri, title: title).save
end

Site.select.each { |r| p r }
```

[This  commit](dd879e089fb71ab0f61044f9175e8146df6a8a23) seems to be addressing the same issue but for Groonga::Array table.
