### PR TITLE
Fix indentation in migration template file

### DIFF
--- a/lib/rails/generators/active_groonga/migration/templates/migration.rb
+++ b/lib/rails/generators/active_groonga/migration/templates/migration.rb
@@ -1,7 +1,7 @@
 class <%= migration_class_name %> < ActiveGroonga::Migration
   def up
 <%- if migration_action -%>
-  change_table(:<%= table_name %>) do |table|
+    change_table(:<%= table_name %>) do |table|
   <% columns.each do |column| -%>
     <%- if migration_action == "add" -%>
       table.<%= column.create_code %>
@@ -9,13 +9,13 @@ class <%= migration_class_name %> < ActiveGroonga::Migration
       table.<%= column.remove_code %>
     <%- end -%>
   <%- end -%>
-  end
+    end
 <%- end -%>
   end
 
   def down
 <%- if migration_action -%>
-  change_table(:<%= table_name %>) do |table|
+    change_table(:<%= table_name %>) do |table|
   <% columns.reverse.each do |column| -%>
     <%- if migration_action == "add" -%>
       table.<%= column.remove_code %>
@@ -23,7 +23,7 @@ class <%= migration_class_name %> < ActiveGroonga::Migration
       table.<%= column.create_code %>
     <%- end -%>
   <%- end -%>
-  end
+    end
 <%- end -%>
   end
 end


### PR DESCRIPTION
This PR fixes indentation of migration files that would be generated with `rails generate groonga:migration`.

When name of migration file starts with 'add' or 'remove', migration outputs "change_table" statement. Indentation of the statement isn't indented property (see below).

``` ruby
class AddSomeToFoo < ActiveGroonga::Migration
  def up
  change_table(:foo) do |table|
  end
  end
  # snip
end
```
