### PR TITLE
Ensure to connect database when load_config

### DIFF
--- a/lib/active_groonga/railties/groonga.rake
+++ b/lib/active_groonga/railties/groonga.rake
@@ -21,6 +21,7 @@ namespace :groonga do
     configurations = Rails.application.config.groonga_configurations
     ActiveGroonga::Base.configurations = configurations
     ActiveGroonga::Base.configure(Rails.env)
+    ActiveGroonga::Base.database.ensure_available
   end
 
   desc "Drops the database."


### PR DESCRIPTION
Hello, I get an error when I try to run Rake tasks.
I don't use Rails but simply try to load some tasks from activegroonga.
With this fix, I can run without error.

Thanks